### PR TITLE
fix: prevent crash when localStorage quota is exceeded

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,16 @@ function fileToDataUrl(file) {
   })
 }
 
+function safeSetJSON(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+    return true
+  } catch (err) {
+    console.warn(`localStorage write failed for ${key}`, err)
+    return false
+  }
+}
+
 function boxStyleFor(styleId, color) {
   switch (styleId) {
     case 'box':
@@ -163,6 +173,7 @@ export default function App() {
   const previewRef = useRef(null)
   const textRef = useRef(null)
   const tabsRef = useRef(null)
+  const saveTimer = useRef(null)
 
   const t = key => STRINGS[appSettings.lang]?.[key] ?? STRINGS.fa[key] ?? key
 
@@ -181,11 +192,15 @@ export default function App() {
   }, [toast])
 
   useEffect(() => {
-    localStorage.setItem(SETTINGS_KEY, JSON.stringify(state))
+    clearTimeout(saveTimer.current)
+    saveTimer.current = setTimeout(() => {
+      if (!safeSetJSON(SETTINGS_KEY, state)) setToast(t('storageFull'))
+    }, 400)
+    return () => clearTimeout(saveTimer.current)
   }, [state])
 
   useEffect(() => {
-    localStorage.setItem(APP_SETTINGS_KEY, JSON.stringify(appSettings))
+    safeSetJSON(APP_SETTINGS_KEY, appSettings)
   }, [appSettings])
 
   useEffect(() => {
@@ -240,10 +255,13 @@ export default function App() {
       const id = `custom-${Date.now()}`
       const entry = { id, label: name, family: `'${name}-${id}'`, rtl: true, dataUrl }
       const next = [...customFonts, entry]
-      setCustomFonts(next)
-      localStorage.setItem(CUSTOM_FONTS_KEY, JSON.stringify(next))
-      update({ fontId: id })
-      setToast(t('fontAdded'))
+      if (safeSetJSON(CUSTOM_FONTS_KEY, next)) {
+        setCustomFonts(next)
+        update({ fontId: id })
+        setToast(t('fontAdded'))
+      } else {
+        setToast(t('storageFull'))
+      }
     } catch {
       setToast(t('fontError'))
     }
@@ -478,9 +496,12 @@ export default function App() {
     }
     const entry = { ...state, id: `${Date.now()}` }
     const next = [entry, ...saved].slice(0, 40)
-    setSaved(next)
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
-    setToast(t('savedToGallery'))
+    if (safeSetJSON(STORAGE_KEY, next)) {
+      setSaved(next)
+      setToast(t('savedToGallery'))
+    } else {
+      setToast(t('storageFull'))
+    }
     setShowSave(false)
   }
 

--- a/src/strings.js
+++ b/src/strings.js
@@ -70,6 +70,7 @@ export const STRINGS = {
     textCopied: 'متن کپی شد',
     writeFirst: 'اول یک متن بنویس',
     savedToGallery: 'در گالری ذخیره شد',
+    storageFull: 'حافظه‌ی مرورگر پر شده — یک طرح یا فونت قدیمی رو حذف کن',
   },
   en: {
     save: 'Save',
@@ -142,5 +143,6 @@ export const STRINGS = {
     textCopied: 'Text copied',
     writeFirst: 'Write some text first',
     savedToGallery: 'Saved to gallery',
+    storageFull: 'Browser storage is full — delete an old design or font',
   },
 }


### PR DESCRIPTION
## مشکل
با آپلود یه پس‌زمینه‌ی حجیم یا ذخیره‌ی چند طرح توی گالری، حجم داده‌ای که هر بار روی localStorage نوشته می‌شه می‌تونه از quota مرورگر (معمولاً ۵-۱۰ مگابایت) رد بشه. چون `localStorage.setItem` بدون try/catch صدا زده می‌شد، این باعث یک exception کنترل‌نشده و از کار افتادن تایپ/برنامه می‌شد — بدون هیچ پیام خطایی به کاربر.

## تغییرات
- یک تابع کمکی `safeSetJSON` اضافه شد که نوشتن روی localStorage رو در try/catch می‌پیچه.
- نوشتن تنظیمات (`state`) روی localStorage دیبانس شد (۴۰۰ میلی‌ثانیه بعد از توقف تغییر) به‌جای هر keystroke، تا هم I/O کمتر بشه هم فشار روی quota.
- ذخیره در گالری و آپلود فونت دلخواه هم از `safeSetJSON` استفاده می‌کنن.
- در صورت پر بودن حافظه، به‌جای کرش، یک toast با پیام مناسب (کلید جدید `storageFull` در فارسی/انگلیسی) نمایش داده می‌شه.
