### PR TITLE
feat: replace window.prompt() with dedicated PromptSheet component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ import { UPDATES, APP_VERSION } from './updates'
 import { checkForUpdate, dismissUpdate } from './updateCheck'
 import { FONT_GOALS } from './goals'
 import { FEATURES } from './features'
+import PromptSheet from './PromptSheet'
 import './App.css'
 import './Landing.css'
 
@@ -232,6 +233,7 @@ export default function App() {
   const [showGoogleFontsSearch, setShowGoogleFontsSearch] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
   const [activeCanvasTool, setActiveCanvasTool] = useState(null)
+  const [promptState, setPromptState] = useState(null)
   const previewRef = useRef(null)
   const textRef = useRef(null)
   const tabsRef = useRef(null)
@@ -1095,6 +1097,17 @@ export default function App() {
     window.location.reload()
   }
 
+  function handlePromptSubmit(value) {
+    if (value == null || !promptState) return
+    const trimmed = value.trim()
+    if (trimmed) {
+      updateLayer(promptState.layerId, { text: trimmed })
+    } else {
+      deleteLayer(promptState.layerId)
+    }
+    setPromptState(null)
+  }
+
   const TABS = [
     { id: 'font', label: t('tabFont'), Icon: I.IconType },
     { id: 'style', label: t('tabStyle'), Icon: I.IconSparkles },
@@ -1210,8 +1223,7 @@ export default function App() {
                   onPointerDown={(e) => handleLayerDrag(e, layer)}
                   onClick={(e) => e.stopPropagation()}
                   onDoubleClick={() => {
-                    const value = window.prompt(t('editLabelText'), layer.text)
-                    if (value != null) updateLayer(layer.id, { text: value })
+                    setPromptState({ layerId: layer.id, initialText: layer.text, promptKey: 'editLabelText' })
                   }}
                 >
                   <LabelArtwork templateId={layer.templateId} color={layer.color} />
@@ -1300,8 +1312,7 @@ export default function App() {
                 onPointerDown={(e) => handleLayerDrag(e, layer)}
                 onClick={(e) => e.stopPropagation()}
                 onDoubleClick={() => {
-                  const val = window.prompt(t('editLayerText'), layer.text)
-                  if (val != null) updateLayer(layer.id, { text: val })
+                  setPromptState({ layerId: layer.id, initialText: layer.text, promptKey: 'editLayerText' })
                 }}
               >
                 {layer.text}
@@ -2364,6 +2375,18 @@ export default function App() {
           <I.ToastCheck size={19} />
           <span>{toast}</span>
         </div>
+      )}
+
+      {promptState && (
+        <PromptSheet
+          title={t(promptState.promptKey)}
+          initialValue={promptState.initialText}
+          placeholder={t('placeholder')}
+          submitLabel={promptState.promptKey === 'editLabelText' ? (t('save')) : (t('save'))}
+          cancelLabel={t('clear')}
+          onSubmit={handlePromptSubmit}
+          onClose={() => setPromptState(null)}
+        />
       )}
 
       {availableUpdate ? (

--- a/src/PromptSheet.jsx
+++ b/src/PromptSheet.jsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from 'react'
+import * as I from './icons'
+
+/**
+ * A lightweight modal prompt that replaces window.prompt().
+ * Slides up as a bottom sheet, auto-focuses the input, and
+ * calls onSubmit(value) when confirmed or onClose() when dismissed.
+ */
+export default function PromptSheet({
+  title,
+  initialValue = '',
+  placeholder = '',
+  submitLabel = 'OK',
+  cancelLabel = 'لغو',
+  onSubmit,
+  onClose,
+}) {
+  const [value, setValue] = useState(initialValue)
+  const [closing, setClosing] = useState(false)
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    // Auto-focus with a tiny delay so the animation starts first
+    const timer = setTimeout(() => inputRef.current?.focus(), 200)
+    return () => clearTimeout(timer)
+  }, [])
+
+  function handleConfirm() {
+    setClosing(true)
+    // Let the close animation play before resolving
+    setTimeout(() => onSubmit(value), 220)
+  }
+
+  function handleCancel() {
+    setClosing(true)
+    setTimeout(onClose, 220)
+  }
+
+  function handleKeyDown(e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleConfirm()
+    }
+    if (e.key === 'Escape') {
+      handleCancel()
+    }
+  }
+
+  return (
+    <div
+      className={`sheet-overlay${closing ? ' closing' : ''}`}
+      onClick={handleCancel}
+    >
+      <div
+        className={`sheet${closing ? ' closing' : ''}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="sheet-grab">
+          <span />
+        </div>
+        <div className="sheet-header">
+          <button className="icon-btn" onClick={handleCancel} aria-label="close">
+            <I.IconX size={14} />
+          </button>
+          <span>{title}</span>
+          <span />
+        </div>
+        <div style={{ padding: '4px 0 20px' }}>
+          <input
+            ref={inputRef}
+            className="text-input"
+            type="text"
+            value={value}
+            placeholder={placeholder}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            style={{ marginBottom: '12px' }}
+          />
+          <div style={{ display: 'flex', gap: '10px' }}>
+            <button
+              className="sheet-item recommended"
+              style={{ marginBottom: 0, flex: 1, justifyContent: 'center' }}
+              onClick={handleConfirm}
+            >
+              <I.IconStar size={16} /> {submitLabel}
+            </button>
+            <button
+              className="sheet-item"
+              style={{ marginBottom: 0, flex: 1, justifyContent: 'center' }}
+              onClick={handleCancel}
+            >
+              <I.IconX size={16} /> {cancelLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- Created src/PromptSheet.jsx — a bottom-sheet modal with text input, auto-focus, Enter/Escape keyboard support, and save/cancel buttons
- Removed both window.prompt() calls in App.jsx (label layer and text layer double-click handlers), replaced with setPromptState() that opens PromptSheet instead