### PR TITLE
ci: align workflows with Node 22 and add PR checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -1,0 +1,25 @@
+name: Pull Request Quality Checks
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-quality-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build


### PR DESCRIPTION
## Summary

- Updates the existing deployment workflow from Node.js 20 to Node.js 22.
- Adds pull request quality checks for `main` using:
  - `npm ci`
  - `npm run lint`
  - `npm run build`

## Why

The repository now uses Capacitor 8 packages that require Node.js 22+, while the deployment workflow was still using Node.js 20.

This also adds automated validation for pull requests before changes reach `main`.

## Validation

Verified locally with Node.js 22:

- `npm ci`
- `npm run lint`
- `npm run build`

No application or package files were changed.